### PR TITLE
Add Jump-Destination Frequency Tables 

### DIFF
--- a/core/vm/stats.go
+++ b/core/vm/stats.go
@@ -17,22 +17,25 @@
 package vm
 
 import (
+	"database/sql"
 	"fmt"
-	"time"
+	"github.com/ethereum/go-ethereum/common"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
 	"math/big"
 	"sync"
-	"github.com/ethereum/go-ethereum/common"
+	"time"
 )
 
 // VM Micro Dataset for profiling
 type VmMicroData struct {
-	opCodeFrequency      map[OpCode]big.Int // opcode frequency statistics
-	opCodeDuration       map[OpCode]big.Int // accumulated duration of opcodes
-	instructionFrequency map[uint64]big.Int // instruction frequency statistics
-	stepLengthFrequency  map[int]big.Int // smart contract length frequency
-	jumpDestFrequency    map[common.Address]map[uint64]uint64  // Jump dest frequency statistics
+	opCodeFrequency      map[OpCode]big.Int                   // opcode frequency statistics
+	opCodeDuration       map[OpCode]big.Int                   // accumulated duration of opcodes
+	instructionFrequency map[uint64]big.Int                   // instruction frequency statistics
+	stepLengthFrequency  map[int]big.Int                      // smart contract length frequency
+	jumpDestFrequency    map[common.Address]map[uint64]uint64 // Jump dest frequency statistics
 	isInitialized        bool
-	mx  sync.Mutex                          // mutex to protect micro dataset 
+	mx                   sync.Mutex // mutex to protect micro dataset
 }
 
 // single global data set for all workers
@@ -40,9 +43,9 @@ var vmStats VmMicroData
 
 func (d *VmMicroData) Initialize() {
 	d.mx.Lock()
-	if (!d.isInitialized) {
+	if !d.isInitialized {
 		d.opCodeFrequency = make(map[OpCode]big.Int)
-		d.opCodeDuration  = make(map[OpCode]big.Int)
+		d.opCodeDuration = make(map[OpCode]big.Int)
 		d.instructionFrequency = make(map[uint64]big.Int)
 		d.stepLengthFrequency = make(map[int]big.Int)
 		d.jumpDestFrequency = make(map[common.Address]map[uint64]uint64)
@@ -53,7 +56,7 @@ func (d *VmMicroData) Initialize() {
 
 // update statistics
 func (d *VmMicroData) UpdateStatistics(contract *common.Address, opCodeFrequency map[OpCode]uint64, opCodeDuration map[OpCode]time.Duration, instructionFrequency map[uint64]uint64, jumpDestFrequency map[uint64]uint64, stepLength int) {
-	// get access to dataset 
+	// get access to dataset
 	d.mx.Lock()
 
 	// update opcode frequency
@@ -79,7 +82,7 @@ func (d *VmMicroData) UpdateStatistics(contract *common.Address, opCodeFrequency
 
 	// update jump destination frequency
 	for jumpDestPc, freq := range jumpDestFrequency {
-		if (d.jumpDestFrequency[*contract] == nil) {
+		if d.jumpDestFrequency[*contract] == nil {
 			d.jumpDestFrequency[*contract] = make(map[uint64]uint64)
 		}
 		d.jumpDestFrequency[*contract][jumpDestPc] += freq
@@ -87,15 +90,15 @@ func (d *VmMicroData) UpdateStatistics(contract *common.Address, opCodeFrequency
 
 	// step length frequency
 	value := d.stepLengthFrequency[stepLength]
-	value.Add(&value,new(big.Int).SetUint64(uint64(1)))
-        d.stepLengthFrequency[stepLength] = value
+	value.Add(&value, new(big.Int).SetUint64(uint64(1)))
+	d.stepLengthFrequency[stepLength] = value
 	// release data set
 	d.mx.Unlock()
 }
 
 // update statistics
 func PrintStatistics() {
-	// get access to dataset 
+	// get access to dataset
 	vmStats.mx.Lock()
 
 	// print opcode frequency
@@ -115,13 +118,64 @@ func PrintStatistics() {
 	}
 
 	// print instruction frequency
-	for instruction, freq  := range vmStats.instructionFrequency {
+	for instruction, freq := range vmStats.instructionFrequency {
 		fmt.Printf("instruction-freq: %v,%v\n", instruction, freq.String())
 	}
 
 	// print step-length frequency
 	for length, freq := range vmStats.stepLengthFrequency {
 		fmt.Printf("steplen-freq: %v,%v\n", length, freq.String())
+	}
+
+	// Dump jump destination frequency statistics into a SQLITE3 database
+
+	// open sqlite3 database
+	db, err := sql.Open("sqlite3", "./jumpdest.db") // Open the created SQLite File
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	defer db.Close()
+
+	// drop jump-dest table
+	const dropJumpDestFrequency string = `DROP TABLE IF EXISTS JumpDestFrequency;`
+	statement, err := db.Prepare(dropJumpDestFrequency)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	_, err = statement.Exec()
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// create new table
+	const createJumpDestFrequency string = `
+	CREATE TABLE JumpDestFrequency (
+	 contract TEXT, 	
+	 jumpdest NUMERIC,
+	 frequency NUMERIC
+	);`
+	statement, err = db.Prepare(createJumpDestFrequency)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	_, err = statement.Exec()
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	// populate values
+	insertFrequency := `INSERT INTO JumpDestFrequency(contract, jumpdest, frequency) VALUES (?, ?, ?)`
+	statement, err = db.Prepare(insertFrequency)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	for contract, freqMap := range vmStats.jumpDestFrequency {
+		for pc, freq := range freqMap {
+			_, err = statement.Exec(contract.String(), pc, freq)
+			if err != nil {
+				log.Fatalln(err.Error())
+			}
+		}
 	}
 
 	// release data set

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
The PR adds new frequency statistics for JUMPDEST instructions. For each executed JUMPDEST, the following information is recorded:
<contract> <pc of JUMPDEST> <frequency>

The information is written into a SQLITE3 database. 
 