### PR TITLE
Replace JUMPDEST by BasicBlock Frequency Stats

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -49,11 +49,10 @@ type ScopeContext struct {
 	Contract *Contract
 }
 
-// BasicBlock contains the address of a basic block, the instructions, and the
-// execution frequency of a basic block.
+// BasicBlock contains the instructions and the execution frequency.
 type BasicBlock struct {
-	Instructions []byte
-	Frequency    uint64
+	Instructions []byte // instructions without parameters for PUSHx
+	Frequency    uint64 // dynamic execution frequency
 }
 
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -49,6 +49,13 @@ type ScopeContext struct {
 	Contract *Contract
 }
 
+// BasicBlock contains the address of a basic block, the instructions, and the
+// execution frequency of a basic block.
+type BasicBlock struct {
+	Instructions []OpCode
+	Frequency    uint64
+}
+
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
 // Read to get a variable amount of data from the hash state. Read is faster than Sum
 // because it doesn't copy the internal state, but also modifies the internal state.
@@ -155,14 +162,14 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		pc   = uint64(0) // program counter
 		cost uint64
 		// copies used by tracer
-		pcCopy             uint64                       // needed for the deferred Tracer
-		gasCopy            uint64                       // for Tracer to log gas remaining before execution
-		logged             bool                         // deferred Tracer should ignore already logged steps
-		res                []byte                       // result of the opcode execution function
-		opCodeFrequency    = map[OpCode]uint64{}        // op-code frequency stats
-		opCodeDuration     = map[OpCode]time.Duration{} // op-code duration stats (accumulated)
-		pcCounterFrequency = map[uint64]uint64{}        // pc-counter frequency stats
-		jumpDestFrequency  = map[uint64]uint64{}        // pc-counter frequency stats
+		pcCopy              uint64                       // needed for the deferred Tracer
+		gasCopy             uint64                       // for Tracer to log gas remaining before execution
+		logged              bool                         // deferred Tracer should ignore already logged steps
+		res                 []byte                       // result of the opcode execution function
+		opCodeFrequency     = map[OpCode]uint64{}        // op-code frequency stats
+		opCodeDuration      = map[OpCode]time.Duration{} // op-code duration stats (accumulated)
+		pcCounterFrequency  = map[uint64]uint64{}        // pc-counter frequency stats
+		basicBlockFrequency = map[uint64]BasicBlock{}     // basic block map that translates an address to a basic block
 
 	)
 	// Don't move this deferrred function, it's placed before the capturestate-deferred method,
@@ -203,7 +210,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			}
 
 			// add observations
-			vmStats.UpdateStatistics(contract.CodeAddr, opCodeFrequency, opCodeDuration, instructionFrequency, jumpDestFrequency, steps)
+			vmStats.UpdateStatistics(contract.CodeAddr, opCodeFrequency, opCodeDuration, instructionFrequency, basicBlockFrequency, steps)
 		}()
 	}
 
@@ -294,7 +301,71 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		)
 
 		if ProfileEVMOpCode && op == JUMPDEST {
-			jumpDestFrequency[pc]++
+			if _, ok := basicBlockFrequency[pc]; !ok {
+				// basic block not found in frequency map
+				// => create new one
+				idx := pc
+				instructions := []OpCode{}
+				length := uint64(len(contract.Code))
+				for {
+
+					// exceed code size
+					if idx >= length {
+						break
+					}
+
+					// fetch op-code
+					op := contract.GetOp(idx)
+					instructions = append(instructions, op)
+
+					// end of basic block?
+					if op == JUMP ||
+						op == JUMPI ||
+						op == STOP ||
+						op == RETURN ||
+						op == REVERT ||
+						op == SELFDESTRUCT {
+						break
+					}
+
+					// skip constant of a push operation
+					if op >= PUSH1 && op <= PUSH32 {
+						numbits := op - PUSH1 + 1
+						if numbits >= 8 {
+							for ; numbits >= 16; numbits -= 16 {
+								idx += 16
+							}
+							for ; numbits >= 8; numbits -= 8 {
+								idx += 8
+							}
+						}
+						switch numbits {
+						case 1:
+							idx += 1
+						case 2:
+							idx += 2
+						case 3:
+							idx += 3
+						case 4:
+							idx += 4
+						case 5:
+							idx += 5
+						case 6:
+							idx += 6
+						case 7:
+							idx += 7
+						}
+
+						// skip to next instruction
+						idx++
+					}
+				}
+				basicBlockFrequency[pc] = BasicBlock{Instructions: instructions, Frequency: 1}
+			} else {
+				bb := basicBlockFrequency[pc] 
+				bb.Frequency ++
+				basicBlockFrequency[pc] = bb
+			}
 		}
 
 		if op == CREATE {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -52,7 +52,7 @@ type ScopeContext struct {
 // BasicBlock contains the address of a basic block, the instructions, and the
 // execution frequency of a basic block.
 type BasicBlock struct {
-	Instructions []OpCode
+	Instructions []byte
 	Frequency    uint64
 }
 
@@ -169,7 +169,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		opCodeFrequency     = map[OpCode]uint64{}        // op-code frequency stats
 		opCodeDuration      = map[OpCode]time.Duration{} // op-code duration stats (accumulated)
 		pcCounterFrequency  = map[uint64]uint64{}        // pc-counter frequency stats
-		basicBlockFrequency = map[uint64]BasicBlock{}     // basic block map that translates an address to a basic block
+		basicBlockFrequency = map[uint64]BasicBlock{}    // basic block map that translates an address to a basic block
 
 	)
 	// Don't move this deferrred function, it's placed before the capturestate-deferred method,
@@ -305,7 +305,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				// basic block not found in frequency map
 				// => create new one
 				idx := pc
-				instructions := []OpCode{}
+				instructions := []byte{}
 				length := uint64(len(contract.Code))
 				for {
 
@@ -316,7 +316,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 					// fetch op-code
 					op := contract.GetOp(idx)
-					instructions = append(instructions, op)
+					instructions = append(instructions, byte(op))
 
 					// end of basic block?
 					if op == JUMP ||
@@ -356,14 +356,15 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 							idx += 7
 						}
 
-						// skip to next instruction
-						idx++
 					}
+
+					// skip to next instruction
+					idx++
 				}
 				basicBlockFrequency[pc] = BasicBlock{Instructions: instructions, Frequency: 1}
 			} else {
-				bb := basicBlockFrequency[pc] 
-				bb.Frequency ++
+				bb := basicBlockFrequency[pc]
+				bb.Frequency++
 				basicBlockFrequency[pc] = bb
 			}
 		}

--- a/core/vm/stats.go
+++ b/core/vm/stats.go
@@ -132,16 +132,16 @@ func PrintStatistics() {
 		fmt.Printf("steplen-freq: %v,%v\n", length, freq.String())
 	}
 
-	// Dump jump destination frequency statistics into a SQLITE3 database
+	// Dump basic-block frequency statistics into a SQLITE3 database
 
 	// open sqlite3 database
-	db, err := sql.Open("sqlite3", "./jumpdest.db") // Open the created SQLite File
+	db, err := sql.Open("sqlite3", "./basicblocks.db") // Open the created SQLite File
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 	defer db.Close()
 
-	// drop jump-dest table
+	// drop basic-block frequency table
 	const dropBasicBlockFrequency string = `DROP TABLE IF EXISTS BasicBlockFrequency;`
 	_, err = db.Exec(dropBasicBlockFrequency)
 	if err != nil {


### PR DESCRIPTION
The JUMPDEST frequency stats would assume that the code of a smart contract does not change. However, this is not quite true for exact measurements. At creation time, a creation code is executed that differs from the deployed contract, and some contracts are self-destructed and overwritten. Hence, we had to record the basic blocks themselves.