### PR TITLE
Add benchmark and performance improvements for LFVM interpreter

### DIFF
--- a/core/vm/lfvm/gas.go
+++ b/core/vm/lfvm/gas.go
@@ -18,12 +18,21 @@ var static_gas_prices_berlin = [NUM_OPCODES]uint64{}
 
 func init() {
 	var gp uint64
-	for i := 0; i < int(NUM_OPCODES); i++ {
+	for i := 0; i < int(NUM_EXECUTABLE_OPCODES); i++ {
 		gp = getStaticGasPriceInternal(OpCode(i))
 		static_gas_prices[i] = gp
 		static_gas_prices_berlin[i] = gp
 	}
 	initBerlinGasPrice()
+
+	for i := 0; i < int(NUM_EXECUTABLE_OPCODES); i++ {
+		if static_gas_prices[i] == UNKNOWN_GAS_PRICE {
+			panic(fmt.Sprintf("Gas price for %v is unkown", OpCode(i)))
+		}
+		if static_gas_prices_berlin[i] == UNKNOWN_GAS_PRICE {
+			panic(fmt.Sprintf("Berlin gas price for %v is unkown", OpCode(i)))
+		}
+	}
 }
 
 func initBerlinGasPrice() {
@@ -41,22 +50,10 @@ func initBerlinGasPrice() {
 }
 
 func getStaticGasPrice(op OpCode, isBerlin bool) uint64 {
-	var res uint64
-	gasPrice := &static_gas_prices
 	if isBerlin {
-		gasPrice = &static_gas_prices_berlin
+		return static_gas_prices_berlin[op]
 	}
-	if int(op) < len(gasPrice) {
-		res = gasPrice[int(op)]
-		if res != UNKNOWN_GAS_PRICE {
-			return res
-		}
-	}
-	res = getStaticGasPriceInternal(op)
-	if res == UNKNOWN_GAS_PRICE {
-		panic(fmt.Sprintf("static gas price for %v unknown", op))
-	}
-	return res
+	return static_gas_prices[op]
 }
 
 func getStaticGasPriceInternal(op OpCode) uint64 {

--- a/core/vm/lfvm/gas.go
+++ b/core/vm/lfvm/gas.go
@@ -49,11 +49,11 @@ func initBerlinGasPrice() {
 	static_gas_prices_berlin[SELFDESTRUCT] = 5000
 }
 
-func getStaticGasPrice(op OpCode, isBerlin bool) uint64 {
+func getStaticGasPrices(isBerlin bool) []uint64 {
 	if isBerlin {
-		return static_gas_prices_berlin[op]
+		return static_gas_prices_berlin[:]
 	}
-	return static_gas_prices[op]
+	return static_gas_prices[:]
 }
 
 func getStaticGasPriceInternal(op OpCode) uint64 {

--- a/core/vm/lfvm/interpreter.go
+++ b/core/vm/lfvm/interpreter.go
@@ -185,14 +185,14 @@ func Run(evm *vm.EVM, cfg vm.Config, contract *vm.Contract, code Code, data []by
 
 func run(c *context) {
 	for c.status == RUNNING {
-
 		if int(c.pc) >= len(c.code) {
 			opStop(c)
 			return
 		}
 
-		for c.code[c.pc].opcode == JUMP_TO {
-			step(c)
+		// JUMP_TO is an LFVM specific operation that has no gas costs.
+		if c.code[c.pc].opcode == JUMP_TO {
+			c.pc = int32(c.code[c.pc].arg)
 		}
 		step(c)
 	}

--- a/core/vm/lfvm/interpreter.go
+++ b/core/vm/lfvm/interpreter.go
@@ -771,34 +771,16 @@ func getGasPrice(c *context, op OpCode) uint64 {
 	return getStaticGasPrice(op, c.isBerlin)
 }
 
-type OperationSet struct {
-	mask [NUM_OPCODES/64 + 1]uint64
-}
-
-func (s *OperationSet) Add(op OpCode) {
-	s.mask[op/64] = s.mask[op/64] | 1<<op%64
-}
-
-func (s *OperationSet) Contains(op OpCode) bool {
-	return op < NUM_OPCODES && s.mask[op/64]&(1<<op%64) != 0
-}
-
-var writeInts = getWriteInstructionMask()
-
-func getWriteInstructionMask() OperationSet {
-	res := OperationSet{}
-	res.Add(SSTORE)
-	res.Add(LOG0)
-	res.Add(LOG1)
-	res.Add(LOG2)
-	res.Add(LOG3)
-	res.Add(LOG4)
-	res.Add(CREATE)
-	res.Add(CREATE2)
-	res.Add(SELFDESTRUCT)
-	return res
-}
-
 func isWriteInstruction(opCode OpCode) bool {
-	return writeInts.Contains(opCode)
+	const mask uint32 = 1 | // = 1 << (SSTORE - SSTORE) |
+		1<<(LOG0-SSTORE) |
+		1<<(LOG1-SSTORE) |
+		1<<(LOG2-SSTORE) |
+		1<<(LOG3-SSTORE) |
+		1<<(LOG4-SSTORE) |
+		1<<(CREATE-SSTORE) |
+		1<<(CREATE2-SSTORE) |
+		1<<(SELFDESTRUCT-SSTORE)
+
+	return SSTORE <= opCode && mask&(1<<(opCode-SSTORE)) != 0
 }

--- a/core/vm/lfvm/interpreter.go
+++ b/core/vm/lfvm/interpreter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
 
@@ -412,11 +413,13 @@ func step(c *context) {
 		return
 	}
 
-	if c.stack.len() < staticStackBoundry[op].stackMin {
+	stackLen := c.stack.len()
+	if stackLen < staticStackBoundry[op].stackMin {
 		c.err = &vm.ErrStackUnderflow{}
 		c.status = ERROR
 		return
-	} else if c.stack.len() > staticStackBoundry[op].stackMax {
+	}
+	if stackLen > int(params.StackLimit)-1 && stackLen > staticStackBoundry[op].stackMax {
 		c.err = &vm.ErrStackOverflow{}
 		c.status = ERROR
 		return

--- a/core/vm/lfvm/interpreter.go
+++ b/core/vm/lfvm/interpreter.go
@@ -184,18 +184,7 @@ func Run(evm *vm.EVM, cfg vm.Config, contract *vm.Contract, code Code, data []by
 }
 
 func run(c *context) {
-	for c.status == RUNNING {
-		if int(c.pc) >= len(c.code) {
-			opStop(c)
-			return
-		}
-
-		// JUMP_TO is an LFVM specific operation that has no gas costs.
-		if c.code[c.pc].opcode == JUMP_TO {
-			c.pc = int32(c.code[c.pc].arg)
-		}
-		step(c)
-	}
+	stepToEnd(c)
 }
 
 func runWithShadowInterpreter(c *context) {
@@ -387,383 +376,406 @@ func runWithStatistics(c *context) {
 }
 
 func step(c *context) {
+	steps(c, true)
+}
 
-	op := c.code[c.pc].opcode
+func stepToEnd(c *context) {
+	steps(c, false)
+}
+func steps(c *context, one_step_only bool) {
+	for c.status == RUNNING {
+		if int(c.pc) >= len(c.code) {
+			opStop(c)
+			return
+		}
 
-	// Catch invalid op-codes here, to avoid the need to check them at other places multiple times.
-	if op >= NUM_EXECUTABLE_OPCODES {
-		c.err = vm.ErrInvalidCode
-		c.status = ERROR
-		return
-	}
+		op := c.code[c.pc].opcode
 
-	// If the interpreter is operating in readonly mode, make sure no
-	// state-modifying operation is performed. The 3rd stack item
-	// for a call operation is the value. Transferring value from one
-	// account to the others means the state is modified and should also
-	// return with an error.
-	if c.readOnly && (isWriteInstruction(op) || (op == CALL && c.stack.Back(2).Sign() != 0)) {
-		c.err = vm.ErrWriteProtection
-		c.status = ERROR
-		return
-	}
+		// JUMP_TO is an LFVM specific operation that has no gas costs.
+		if c.code[c.pc].opcode == JUMP_TO {
+			c.pc = int32(c.code[c.pc].arg)
+			op = c.code[c.pc].opcode
+		}
 
-	// Consume static gas price for instruction before execution
-	if !c.UseGas(getGasPrice(c, op)) {
-		return
-	}
+		// Catch invalid op-codes here, to avoid the need to check them at other places multiple times.
+		if op >= NUM_EXECUTABLE_OPCODES {
+			c.err = vm.ErrInvalidCode
+			c.status = ERROR
+			return
+		}
 
-	stackLen := c.stack.len()
-	if stackLen < staticStackBoundry[op].stackMin {
-		c.err = &vm.ErrStackUnderflow{}
-		c.status = ERROR
-		return
-	}
-	if stackLen > int(params.StackLimit)-1 && stackLen > staticStackBoundry[op].stackMax {
-		c.err = &vm.ErrStackOverflow{}
-		c.status = ERROR
-		return
-	}
+		// If the interpreter is operating in readonly mode, make sure no
+		// state-modifying operation is performed. The 3rd stack item
+		// for a call operation is the value. Transferring value from one
+		// account to the others means the state is modified and should also
+		// return with an error.
+		if c.readOnly && (isWriteInstruction(op) || (op == CALL && c.stack.Back(2).Sign() != 0)) {
+			c.err = vm.ErrWriteProtection
+			c.status = ERROR
+			return
+		}
 
-	// Execute instruction
-	switch op {
-	case POP:
-		opPop(c)
-	case PUSH1:
-		opPush1(c)
-	case PUSH2:
-		opPush2(c)
-	case PUSH3:
-		opPush3(c)
-	case PUSH4:
-		opPush4(c)
-	case PUSH5:
-		opPush(c, 5)
-	case PUSH31:
-		opPush(c, 31)
-	case PUSH32:
-		opPush32(c)
-	case JUMP:
-		opJump(c)
-	case JUMPDEST:
-		// nothing
-	case SWAP1:
-		opSwap(c, 1)
-	case SWAP2:
-		opSwap(c, 2)
-	case DUP3:
-		opDup(c, 3)
-	case AND:
-		opAnd(c)
-	case SWAP3:
-		opSwap(c, 3)
-	case JUMPI:
-		opJumpi(c)
-	case GT:
-		opGt(c)
-	case DUP4:
-		opDup(c, 4)
-	case DUP2:
-		opDup(c, 2)
-	case ISZERO:
-		opIszero(c)
-	case ADD:
-		opAdd(c)
-	case OR:
-		opOr(c)
-	case XOR:
-		opXor(c)
-	case NOT:
-		opNot(c)
-	case SUB:
-		opSub(c)
-	case MUL:
-		opMul(c)
-	case MULMOD:
-		opMulMod(c)
-	case DIV:
-		opDiv(c)
-	case SDIV:
-		opSDiv(c)
-	case MOD:
-		opMod(c)
-	case SMOD:
-		opSMod(c)
-	case ADDMOD:
-		opAddMod(c)
-	case EXP:
-		opExp(c)
-	case DUP5:
-		opDup(c, 5)
-	case DUP1:
-		opDup(c, 1)
-	case EQ:
-		opEq(c)
-	case PC:
-		opPc(c)
-	case CALLER:
-		opCaller(c)
-	case CALLDATALOAD:
-		opCallDataload(c)
-	case CALLDATASIZE:
-		opCallDatasize(c)
-	case CALLDATACOPY:
-		opCallDataCopy(c)
-	case MLOAD:
-		opMload(c)
-	case MSTORE:
-		opMstore(c)
-	case MSTORE8:
-		opMstore8(c)
-	case MSIZE:
-		opMsize(c)
-	case LT:
-		opLt(c)
-	case SLT:
-		opSlt(c)
-	case SGT:
-		opSgt(c)
-	case SHR:
-		opShr(c)
-	case SHL:
-		opShl(c)
-	case SAR:
-		opSar(c)
-	case SIGNEXTEND:
-		opSignExtend(c)
-	case BYTE:
-		opByte(c)
-	case SHA3:
-		opSha3(c)
-	case CALLVALUE:
-		opCallvalue(c)
-	case PUSH6:
-		opPush(c, 6)
-	case PUSH7:
-		opPush(c, 7)
-	case PUSH8:
-		opPush(c, 8)
-	case PUSH9:
-		opPush(c, 9)
-	case PUSH10:
-		opPush(c, 10)
-	case PUSH11:
-		opPush(c, 11)
-	case PUSH12:
-		opPush(c, 12)
-	case PUSH13:
-		opPush(c, 13)
-	case PUSH14:
-		opPush(c, 14)
-	case PUSH15:
-		opPush(c, 15)
-	case PUSH16:
-		opPush(c, 16)
-	case PUSH17:
-		opPush(c, 17)
-	case PUSH18:
-		opPush(c, 18)
-	case PUSH19:
-		opPush(c, 19)
-	case PUSH20:
-		opPush(c, 20)
-	case PUSH21:
-		opPush(c, 21)
-	case PUSH22:
-		opPush(c, 22)
-	case PUSH23:
-		opPush(c, 23)
-	case PUSH24:
-		opPush(c, 24)
-	case PUSH25:
-		opPush(c, 25)
-	case PUSH26:
-		opPush(c, 26)
-	case PUSH27:
-		opPush(c, 27)
-	case PUSH28:
-		opPush(c, 28)
-	case PUSH29:
-		opPush(c, 29)
-	case PUSH30:
-		opPush(c, 30)
-	case SWAP4:
-		opSwap(c, 4)
-	case SWAP5:
-		opSwap(c, 5)
-	case SWAP6:
-		opSwap(c, 6)
-	case SWAP7:
-		opSwap(c, 7)
-	case SWAP8:
-		opSwap(c, 8)
-	case SWAP9:
-		opSwap(c, 9)
-	case SWAP10:
-		opSwap(c, 10)
-	case SWAP11:
-		opSwap(c, 11)
-	case SWAP12:
-		opSwap(c, 12)
-	case SWAP13:
-		opSwap(c, 13)
-	case SWAP14:
-		opSwap(c, 14)
-	case SWAP15:
-		opSwap(c, 15)
-	case SWAP16:
-		opSwap(c, 16)
-	case DUP6:
-		opDup(c, 6)
-	case DUP7:
-		opDup(c, 7)
-	case DUP8:
-		opDup(c, 8)
-	case DUP9:
-		opDup(c, 9)
-	case DUP10:
-		opDup(c, 10)
-	case DUP11:
-		opDup(c, 11)
-	case DUP12:
-		opDup(c, 12)
-	case DUP13:
-		opDup(c, 13)
-	case DUP14:
-		opDup(c, 14)
-	case DUP15:
-		opDup(c, 15)
-	case DUP16:
-		opDup(c, 16)
-	case RETURN:
-		opReturn(c)
-	case REVERT:
-		opRevert(c)
-	case JUMP_TO:
-		opJumpTo(c)
-	case NOOP:
-		opNoop(c)
-	case DATA:
-		panic("can not interpret data as instruction")
-	case INVALID:
-		opInvalid(c)
-	case SLOAD:
-		opSload(c)
-	case SSTORE:
-		opSstore(c)
-	case CODESIZE:
-		opCodeSize(c)
-	case CODECOPY:
-		opCodeCopy(c)
-	case EXTCODESIZE:
-		opExtcodesize(c)
-	case EXTCODEHASH:
-		opExtcodehash(c)
-	case EXTCODECOPY:
-		opExtCodeCopy(c)
-	case BALANCE:
-		opBalance(c)
-	case SELFBALANCE:
-		opSelfbalance(c)
-	case BASEFEE:
-		opBaseFee(c)
-	case SELFDESTRUCT:
-		opSelfdestruct(c)
-	case CHAINID:
-		opChainId(c)
-	case GAS:
-		opGas(c)
-	case DIFFICULTY:
-		opDifficulty(c)
-	case TIMESTAMP:
-		opTimestamp(c)
-	case NUMBER:
-		opNumber(c)
-	case GASLIMIT:
-		opGasLimit(c)
-	case GASPRICE:
-		opGasPrice(c)
-	case CALL:
-		opCall(c)
-	case CALLCODE:
-		opCallCode(c)
-	case STATICCALL:
-		opStaticCall(c)
-	case DELEGATECALL:
-		opDelegateCall(c)
-	case RETURNDATASIZE:
-		opReturnDataSize(c)
-	case RETURNDATACOPY:
-		opReturnDataCopy(c)
-	case BLOCKHASH:
-		opBlockhash(c)
-	case COINBASE:
-		opCoinbase(c)
-	case ORIGIN:
-		opOrigin(c)
-	case ADDRESS:
-		opAddress(c)
-	case STOP:
-		opStop(c)
-	case CREATE:
-		opCreate(c)
-	case CREATE2:
-		opCreate2(c)
-	case LOG0:
-		opLog(c, 0)
-	case LOG1:
-		opLog(c, 1)
-	case LOG2:
-		opLog(c, 2)
-	case LOG3:
-		opLog(c, 3)
-	case LOG4:
-		opLog(c, 4)
-	// --- Super Instructions ---
-	case SWAP2_SWAP1_POP_JUMP:
-		opSwap2_Swap1_Pop_Jump(c)
-	case SWAP1_POP_SWAP2_SWAP1:
-		opSwap1_Pop_Swap2_Swap1(c)
-	case POP_SWAP2_SWAP1_POP:
-		opPop_Swap2_Swap1_Pop(c)
-	case POP_POP:
-		opPopPop(c)
-	case PUSH1_SHL:
-		opPush1_Shl(c)
-	case PUSH1_ADD:
-		opPush1_Add(c)
-	case PUSH1_DUP1:
-		opPush1_Dup1(c)
-	case PUSH2_JUMP:
-		opPush2_Jump(c)
-	case PUSH2_JUMPI:
-		opPush2_Jumpi(c)
-	case PUSH1_PUSH1:
-		opPush1_Push1(c)
-	case SWAP1_POP:
-		opSwap1_Pop(c)
-	case POP_JUMP:
-		opPop_Jump(c)
-	case SWAP2_SWAP1:
-		opSwap2_Swap1(c)
-	case SWAP2_POP:
-		opSwap2_Pop(c)
-	case DUP2_MSTORE:
-		opDup2_Mstore(c)
-	case DUP2_LT:
-		opDup2_Lt(c)
-	case ISZERO_PUSH2_JUMPI:
-		opIsZero_Push2_Jumpi(c)
-	case PUSH1_PUSH4_DUP3:
-		opPush1_Push4_Dup3(c)
-	case AND_SWAP1_POP_SWAP2_SWAP1:
-		opAnd_Swap1_Pop_Swap2_Swap1(c)
-	case PUSH1_PUSH1_PUSH1_SHL_SUB:
-		opPush1_Push1_Push1_Shl_Sub(c)
-	default:
-		panic(fmt.Sprintf("Unsupported operation: %v", op))
+		// Consume static gas price for instruction before execution
+		if !c.UseGas(getGasPrice(c, op)) {
+			return
+		}
+
+		stackLen := c.stack.len()
+		if stackLen < staticStackBoundry[op].stackMin {
+			c.err = &vm.ErrStackUnderflow{}
+			c.status = ERROR
+			return
+		}
+		if stackLen > int(params.StackLimit)-1 && stackLen > staticStackBoundry[op].stackMax {
+			c.err = &vm.ErrStackOverflow{}
+			c.status = ERROR
+			return
+		}
+
+		// Execute instruction
+		switch op {
+		case POP:
+			opPop(c)
+		case PUSH1:
+			opPush1(c)
+		case PUSH2:
+			opPush2(c)
+		case PUSH3:
+			opPush3(c)
+		case PUSH4:
+			opPush4(c)
+		case PUSH5:
+			opPush(c, 5)
+		case PUSH31:
+			opPush(c, 31)
+		case PUSH32:
+			opPush32(c)
+		case JUMP:
+			opJump(c)
+		case JUMPDEST:
+			// nothing
+		case SWAP1:
+			opSwap(c, 1)
+		case SWAP2:
+			opSwap(c, 2)
+		case DUP3:
+			opDup(c, 3)
+		case AND:
+			opAnd(c)
+		case SWAP3:
+			opSwap(c, 3)
+		case JUMPI:
+			opJumpi(c)
+		case GT:
+			opGt(c)
+		case DUP4:
+			opDup(c, 4)
+		case DUP2:
+			opDup(c, 2)
+		case ISZERO:
+			opIszero(c)
+		case ADD:
+			opAdd(c)
+		case OR:
+			opOr(c)
+		case XOR:
+			opXor(c)
+		case NOT:
+			opNot(c)
+		case SUB:
+			opSub(c)
+		case MUL:
+			opMul(c)
+		case MULMOD:
+			opMulMod(c)
+		case DIV:
+			opDiv(c)
+		case SDIV:
+			opSDiv(c)
+		case MOD:
+			opMod(c)
+		case SMOD:
+			opSMod(c)
+		case ADDMOD:
+			opAddMod(c)
+		case EXP:
+			opExp(c)
+		case DUP5:
+			opDup(c, 5)
+		case DUP1:
+			opDup(c, 1)
+		case EQ:
+			opEq(c)
+		case PC:
+			opPc(c)
+		case CALLER:
+			opCaller(c)
+		case CALLDATALOAD:
+			opCallDataload(c)
+		case CALLDATASIZE:
+			opCallDatasize(c)
+		case CALLDATACOPY:
+			opCallDataCopy(c)
+		case MLOAD:
+			opMload(c)
+		case MSTORE:
+			opMstore(c)
+		case MSTORE8:
+			opMstore8(c)
+		case MSIZE:
+			opMsize(c)
+		case LT:
+			opLt(c)
+		case SLT:
+			opSlt(c)
+		case SGT:
+			opSgt(c)
+		case SHR:
+			opShr(c)
+		case SHL:
+			opShl(c)
+		case SAR:
+			opSar(c)
+		case SIGNEXTEND:
+			opSignExtend(c)
+		case BYTE:
+			opByte(c)
+		case SHA3:
+			opSha3(c)
+		case CALLVALUE:
+			opCallvalue(c)
+		case PUSH6:
+			opPush(c, 6)
+		case PUSH7:
+			opPush(c, 7)
+		case PUSH8:
+			opPush(c, 8)
+		case PUSH9:
+			opPush(c, 9)
+		case PUSH10:
+			opPush(c, 10)
+		case PUSH11:
+			opPush(c, 11)
+		case PUSH12:
+			opPush(c, 12)
+		case PUSH13:
+			opPush(c, 13)
+		case PUSH14:
+			opPush(c, 14)
+		case PUSH15:
+			opPush(c, 15)
+		case PUSH16:
+			opPush(c, 16)
+		case PUSH17:
+			opPush(c, 17)
+		case PUSH18:
+			opPush(c, 18)
+		case PUSH19:
+			opPush(c, 19)
+		case PUSH20:
+			opPush(c, 20)
+		case PUSH21:
+			opPush(c, 21)
+		case PUSH22:
+			opPush(c, 22)
+		case PUSH23:
+			opPush(c, 23)
+		case PUSH24:
+			opPush(c, 24)
+		case PUSH25:
+			opPush(c, 25)
+		case PUSH26:
+			opPush(c, 26)
+		case PUSH27:
+			opPush(c, 27)
+		case PUSH28:
+			opPush(c, 28)
+		case PUSH29:
+			opPush(c, 29)
+		case PUSH30:
+			opPush(c, 30)
+		case SWAP4:
+			opSwap(c, 4)
+		case SWAP5:
+			opSwap(c, 5)
+		case SWAP6:
+			opSwap(c, 6)
+		case SWAP7:
+			opSwap(c, 7)
+		case SWAP8:
+			opSwap(c, 8)
+		case SWAP9:
+			opSwap(c, 9)
+		case SWAP10:
+			opSwap(c, 10)
+		case SWAP11:
+			opSwap(c, 11)
+		case SWAP12:
+			opSwap(c, 12)
+		case SWAP13:
+			opSwap(c, 13)
+		case SWAP14:
+			opSwap(c, 14)
+		case SWAP15:
+			opSwap(c, 15)
+		case SWAP16:
+			opSwap(c, 16)
+		case DUP6:
+			opDup(c, 6)
+		case DUP7:
+			opDup(c, 7)
+		case DUP8:
+			opDup(c, 8)
+		case DUP9:
+			opDup(c, 9)
+		case DUP10:
+			opDup(c, 10)
+		case DUP11:
+			opDup(c, 11)
+		case DUP12:
+			opDup(c, 12)
+		case DUP13:
+			opDup(c, 13)
+		case DUP14:
+			opDup(c, 14)
+		case DUP15:
+			opDup(c, 15)
+		case DUP16:
+			opDup(c, 16)
+		case RETURN:
+			opReturn(c)
+		case REVERT:
+			opRevert(c)
+		case JUMP_TO:
+			opJumpTo(c)
+		case NOOP:
+			opNoop(c)
+		case DATA:
+			panic("can not interpret data as instruction")
+		case INVALID:
+			opInvalid(c)
+		case SLOAD:
+			opSload(c)
+		case SSTORE:
+			opSstore(c)
+		case CODESIZE:
+			opCodeSize(c)
+		case CODECOPY:
+			opCodeCopy(c)
+		case EXTCODESIZE:
+			opExtcodesize(c)
+		case EXTCODEHASH:
+			opExtcodehash(c)
+		case EXTCODECOPY:
+			opExtCodeCopy(c)
+		case BALANCE:
+			opBalance(c)
+		case SELFBALANCE:
+			opSelfbalance(c)
+		case BASEFEE:
+			opBaseFee(c)
+		case SELFDESTRUCT:
+			opSelfdestruct(c)
+		case CHAINID:
+			opChainId(c)
+		case GAS:
+			opGas(c)
+		case DIFFICULTY:
+			opDifficulty(c)
+		case TIMESTAMP:
+			opTimestamp(c)
+		case NUMBER:
+			opNumber(c)
+		case GASLIMIT:
+			opGasLimit(c)
+		case GASPRICE:
+			opGasPrice(c)
+		case CALL:
+			opCall(c)
+		case CALLCODE:
+			opCallCode(c)
+		case STATICCALL:
+			opStaticCall(c)
+		case DELEGATECALL:
+			opDelegateCall(c)
+		case RETURNDATASIZE:
+			opReturnDataSize(c)
+		case RETURNDATACOPY:
+			opReturnDataCopy(c)
+		case BLOCKHASH:
+			opBlockhash(c)
+		case COINBASE:
+			opCoinbase(c)
+		case ORIGIN:
+			opOrigin(c)
+		case ADDRESS:
+			opAddress(c)
+		case STOP:
+			opStop(c)
+		case CREATE:
+			opCreate(c)
+		case CREATE2:
+			opCreate2(c)
+		case LOG0:
+			opLog(c, 0)
+		case LOG1:
+			opLog(c, 1)
+		case LOG2:
+			opLog(c, 2)
+		case LOG3:
+			opLog(c, 3)
+		case LOG4:
+			opLog(c, 4)
+		// --- Super Instructions ---
+		case SWAP2_SWAP1_POP_JUMP:
+			opSwap2_Swap1_Pop_Jump(c)
+		case SWAP1_POP_SWAP2_SWAP1:
+			opSwap1_Pop_Swap2_Swap1(c)
+		case POP_SWAP2_SWAP1_POP:
+			opPop_Swap2_Swap1_Pop(c)
+		case POP_POP:
+			opPopPop(c)
+		case PUSH1_SHL:
+			opPush1_Shl(c)
+		case PUSH1_ADD:
+			opPush1_Add(c)
+		case PUSH1_DUP1:
+			opPush1_Dup1(c)
+		case PUSH2_JUMP:
+			opPush2_Jump(c)
+		case PUSH2_JUMPI:
+			opPush2_Jumpi(c)
+		case PUSH1_PUSH1:
+			opPush1_Push1(c)
+		case SWAP1_POP:
+			opSwap1_Pop(c)
+		case POP_JUMP:
+			opPop_Jump(c)
+		case SWAP2_SWAP1:
+			opSwap2_Swap1(c)
+		case SWAP2_POP:
+			opSwap2_Pop(c)
+		case DUP2_MSTORE:
+			opDup2_Mstore(c)
+		case DUP2_LT:
+			opDup2_Lt(c)
+		case ISZERO_PUSH2_JUMPI:
+			opIsZero_Push2_Jumpi(c)
+		case PUSH1_PUSH4_DUP3:
+			opPush1_Push4_Dup3(c)
+		case AND_SWAP1_POP_SWAP2_SWAP1:
+			opAnd_Swap1_Pop_Swap2_Swap1(c)
+		case PUSH1_PUSH1_PUSH1_SHL_SUB:
+			opPush1_Push1_Push1_Shl_Sub(c)
+		default:
+			panic(fmt.Sprintf("Unsupported operation: %v", op))
+		}
+		c.pc++
+
+		if one_step_only {
+			return
+		}
 	}
-	c.pc++
 }
 
 func getGasPrice(c *context, op OpCode) uint64 {

--- a/core/vm/lfvm/interpreter.go
+++ b/core/vm/lfvm/interpreter.go
@@ -389,6 +389,13 @@ func step(c *context) {
 
 	op := c.code[c.pc].opcode
 
+	// Catch invalid op-codes here, to avoid the need to check them at other places multiple times.
+	if op >= NUM_EXECUTABLE_OPCODES {
+		c.err = vm.ErrInvalidCode
+		c.status = ERROR
+		return
+	}
+
 	// If the interpreter is operating in readonly mode, make sure no
 	// state-modifying operation is performed. The 3rd stack item
 	// for a call operation is the value. Transferring value from one

--- a/core/vm/lfvm/interpreter_test.go
+++ b/core/vm/lfvm/interpreter_test.go
@@ -1,0 +1,121 @@
+package lfvm
+
+import (
+	"encoding/hex"
+	"log"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+// To run the benchmark use
+//  go test ./core/vm/lfvm -bench=.*Fib.* --benchtime 10s
+
+type example struct {
+	code     []byte // Some contract code
+	function uint32 // The identifier of the function in the contract to be called
+}
+
+func getFibExample() example {
+	// An implementation of the fib function in EVM byte code.
+	code, err := hex.DecodeString("608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f9b7c7e514610030575b600080fd5b61004a600480360381019061004591906100f6565b610060565b6040516100579190610132565b60405180910390f35b600060018263ffffffff161161007957600190506100b0565b61008e600283610089919061017c565b610060565b6100a360018461009e919061017c565b610060565b6100ad91906101b4565b90505b919050565b600080fd5b600063ffffffff82169050919050565b6100d3816100ba565b81146100de57600080fd5b50565b6000813590506100f0816100ca565b92915050565b60006020828403121561010c5761010b6100b5565b5b600061011a848285016100e1565b91505092915050565b61012c816100ba565b82525050565b60006020820190506101476000830184610123565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b6000610187826100ba565b9150610192836100ba565b9250828203905063ffffffff8111156101ae576101ad61014d565b5b92915050565b60006101bf826100ba565b91506101ca836100ba565b9250828201905063ffffffff8111156101e6576101e561014d565b5b9291505056fea26469706673582212207fd33e47e97ce5871bb05401e6710238af535ae8aeaab013ca9a9c29152b8a1b64736f6c637827302e382e31372d646576656c6f702e323032322e382e392b636f6d6d69742e62623161386466390058")
+	if err != nil {
+		log.Fatalf("Unable to decode fib-code: %v", err)
+	}
+
+	return example{
+		code:     code,
+		function: 0xF9B7C7E5, // The function selector for the fib function.
+	}
+}
+
+func fib(x int) int {
+	if x <= 1 {
+		return 1
+	}
+	return fib(x-1) + fib(x-2)
+}
+
+func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
+	example := getFibExample()
+
+	// Convert example to LFVM format.
+	converted, err := convert(example.code, with_super_instructions)
+	if err != nil {
+		b.Fatalf("error converting code: %v", err)
+	}
+
+	// Create input data.
+
+	// See details of argument encoding: t.ly/kBl6
+	data := make([]byte, 4+32) // < the parameter is padded up to 32 bytes
+
+	// Encode function selector in big-endian format.
+	data[0] = byte(example.function >> 24)
+	data[1] = byte(example.function >> 16)
+	data[2] = byte(example.function >> 8)
+	data[3] = byte(example.function)
+
+	// Encode argument as a big-endian value.
+	data[4+28] = byte(arg >> 24)
+	data[5+28] = byte(arg >> 16)
+	data[6+28] = byte(arg >> 8)
+	data[7+28] = byte(arg)
+
+	// Create a dummy contract
+	addr := vm.AccountRef{}
+	contract := vm.NewContract(addr, addr, big.NewInt(0), 1<<63)
+
+	// Create execution context.
+	ctxt := context{
+		code:     converted,
+		data:     data,
+		callsize: *uint256.NewInt(uint64(len(data))),
+		stack:    NewStack(),
+		memory:   NewMemory(),
+		readOnly: true,
+		contract: contract,
+	}
+
+	// Compute expected value.
+	wanted := fib(arg)
+
+	for i := 0; i < b.N; i++ {
+		// Reset the context.
+		ctxt.pc = 0
+		ctxt.status = RUNNING
+		ctxt.contract.Gas = 1 << 31
+		ctxt.stack.stack_ptr = 0
+
+		// Run the code (actual benchmark).
+		run(&ctxt)
+
+		// Check the result.
+		if ctxt.status != RETURNED {
+			b.Fatalf("execution failed: status is %v, error %v", ctxt.status, ctxt.err)
+		}
+
+		size := ctxt.result_size
+		if size.Uint64() != 32 {
+			b.Fatalf("unexpected length of end; wanted 32, got %d", size.Uint64())
+		}
+		res := make([]byte, size.Uint64())
+		offset := ctxt.result_offset
+		ctxt.memory.CopyData(offset.Uint64(), res)
+
+		got := (int(res[28]) << 24) | (int(res[29]) << 16) | (int(res[30]) << 8) | (int(res[31]) << 0)
+		if wanted != got {
+			b.Fatalf("unexpected result, wanted %d, got %d", wanted, got)
+		}
+	}
+}
+
+func BenchmarkFib10(b *testing.B) {
+	benchmarkFib(b, 10, false)
+}
+
+func BenchmarkFib10_SI(b *testing.B) {
+	benchmarkFib(b, 10, true)
+}

--- a/core/vm/lfvm/interpreter_test.go
+++ b/core/vm/lfvm/interpreter_test.go
@@ -119,3 +119,11 @@ func BenchmarkFib10(b *testing.B) {
 func BenchmarkFib10_SI(b *testing.B) {
 	benchmarkFib(b, 10, true)
 }
+
+var sink bool
+
+func BenchmarkIsWriteInstruction(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		sink = isWriteInstruction(OpCode(i % int(NUM_EXECUTABLE_OPCODES)))
+	}
+}

--- a/core/vm/lfvm/opcode.go
+++ b/core/vm/lfvm/opcode.go
@@ -202,6 +202,9 @@ const (
 	AND_SWAP1_POP_SWAP2_SWAP1
 	PUSH1_PUSH1_PUSH1_SHL_SUB
 
+	// Not really an Op-code but used to get the number of executable opcodes.
+	NUM_EXECUTABLE_OPCODES
+
 	// Special no-instrictions op codes
 	DATA
 	NOOP


### PR DESCRIPTION
This PR adds a benchmark for interpreting a program using the LFVM and applies a number of improvements to reduce the runtime of the interpreter (~ 35% reduction without super instructions and ~ 30-40% reduction with super instructions).

Before:
```
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkFib10-32                  83112            142676 ns/op
BenchmarkFib10_SI-32              115978             99989 ns/op
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkFib10-12       	   35463	    334699 ns/op
BenchmarkFib10_SI-12    	   54075	    235483 ns/op
```

After:
```
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkFib10-32                 135072             92556 ns/op       
BenchmarkFib10_SI-32              168900             70866 ns/op 
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
BenchmarkFib10-12       	   62058	    205308 ns/op
BenchmarkFib10_SI-12    	   90363	    134781 ns/op
```