### PR TITLE
Allow replacing StateDB with a different implementation

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -455,8 +455,7 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 func (b *SimulatedBackend) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
-	return b.pendingState.GetOrNewStateObject(account).Nonce(), nil
+	return b.pendingState.GetNonce(account), nil
 }
 
 // SuggestGasPrice implements ContractTransactor.SuggestGasPrice. Since the simulated
@@ -617,8 +616,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		call.Value = new(big.Int)
 	}
 	// Set infinite balance to the fake caller account.
-	from := stateDB.GetOrNewStateObject(call.From)
-	from.SetBalance(math.MaxBig256)
+	stateDB.SetBalance(call.From, math.MaxBig256)
 	// Execute the call.
 	msg := callMsg{call}
 

--- a/core/state/adapter.go
+++ b/core/state/adapter.go
@@ -1,0 +1,138 @@
+package state
+
+import (
+	"encoding/json"
+	substate "github.com/Fantom-foundation/Substate"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+	"time"
+)
+
+type StateDbInterface interface {
+	StartPrefetcher(namespace string)
+	StopPrefetcher()
+	Error() error
+	AddLog(log *types.Log)
+	GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log
+	Logs() []*types.Log
+	AddPreimage(hash common.Hash, preimage []byte)
+	Preimages() map[common.Hash][]byte
+	AddRefund(gas uint64)
+	SubRefund(gas uint64)
+	Exist(addr common.Address) bool
+	Empty(addr common.Address) bool
+	GetBalance(addr common.Address) *big.Int
+	GetNonce(addr common.Address) uint64
+	TxIndex() int
+	GetCode(addr common.Address) []byte
+	GetCodeSize(addr common.Address) int
+	GetCodeHash(addr common.Address) common.Hash
+	GetState(addr common.Address, hash common.Hash) common.Hash
+	GetProof(addr common.Address) ([][]byte, error)
+	GetProofByHash(addrHash common.Hash) ([][]byte, error)
+	GetStorageProof(a common.Address, key common.Hash) ([][]byte, error)
+	GetCommittedState(addr common.Address, hash common.Hash) common.Hash
+	Database() Database
+	StorageTrie(addr common.Address) Trie
+	HasSuicided(addr common.Address) bool
+	AddBalance(addr common.Address, amount *big.Int)
+	SubBalance(addr common.Address, amount *big.Int)
+	SetBalance(addr common.Address, amount *big.Int)
+	SetNonce(addr common.Address, nonce uint64)
+	SetCode(addr common.Address, code []byte)
+	SetState(addr common.Address, key, value common.Hash)
+	SetStorage(addr common.Address, storage map[common.Hash]common.Hash)
+	Suicide(addr common.Address) bool
+	CreateAccount(addr common.Address)
+	ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) error
+	Copy() StateDbInterface
+	Snapshot() int
+	RevertToSnapshot(revid int)
+	GetRefund() uint64
+	Finalise(deleteEmptyObjects bool)
+	IntermediateRoot(deleteEmptyObjects bool) common.Hash
+	Prepare(thash common.Hash, ti int)
+	Commit(deleteEmptyObjects bool) (common.Hash, error)
+	PrepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList)
+	AddAddressToAccessList(addr common.Address)
+	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddressInAccessList(addr common.Address) bool
+	SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool)
+
+	RawDump(opts *DumpConfig) Dump
+	IteratorDump(opts *DumpConfig) IteratorDump
+	IterativeDump(opts *DumpConfig, output *json.Encoder)
+	Dump(opts *DumpConfig) []byte
+	DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte)
+
+	GetAccountReads() time.Duration
+	GetAccountHashes() time.Duration
+	GetAccountUpdates() time.Duration
+	GetAccountCommits() time.Duration
+	GetStorageReads() time.Duration
+	GetStorageHashes() time.Duration
+	GetStorageUpdates() time.Duration
+	GetStorageCommits() time.Duration
+	GetSnapshotAccountReads() time.Duration
+	GetSnapshotStorageReads() time.Duration
+	GetSnapshotCommits() time.Duration
+
+	SetPrehashedCode(addr common.Address, hash common.Hash, code []byte)
+	GetSubstatePostAlloc() substate.SubstateAlloc
+}
+
+type StateDB struct {
+	StateDbInterface
+
+	// Measurements gathered during execution for debugging purposes
+	AccountReads         time.Duration
+	AccountHashes        time.Duration
+	AccountUpdates       time.Duration
+	AccountCommits       time.Duration
+	StorageReads         time.Duration
+	StorageHashes        time.Duration
+	StorageUpdates       time.Duration
+	StorageCommits       time.Duration
+	SnapshotAccountReads time.Duration
+	SnapshotStorageReads time.Duration
+	SnapshotCommits      time.Duration
+}
+
+func (s *StateDB) Copy() *StateDB {
+	return &StateDB{ s.StateDbInterface.Copy(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+}
+
+func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	hash, err := s.StateDbInterface.Commit(deleteEmptyObjects)
+	s.AccountReads = s.GetAccountReads()
+	s.AccountHashes = s.GetAccountHashes()
+	s.AccountUpdates = s.GetAccountUpdates()
+	s.AccountCommits = s.GetAccountCommits()
+	s.StorageReads = s.GetStorageReads()
+	s.StorageHashes = s.GetStorageHashes()
+	s.StorageUpdates = s.GetStorageUpdates()
+	s.StorageCommits = s.GetStorageCommits()
+	s.SnapshotAccountReads = s.GetSnapshotAccountReads()
+	s.SnapshotStorageReads = s.GetSnapshotStorageReads()
+	s.SnapshotCommits = s.GetSnapshotCommits()
+	return hash, err
+}
+
+// New creates a new state from a given trie.
+func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) {
+	return NewWithSnapLayers(root, db, snaps, 128)
+}
+
+func NewWithSnapLayers(root common.Hash, db Database, snaps *snapshot.Tree, layers int) (*StateDB, error) {
+	sdb, err := NewLegacyWithSnapLayers(root, db, snaps, layers)
+	if err != nil {
+		return nil, err
+	}
+	return NewWrapper(sdb), nil
+}
+
+func NewWrapper(inner StateDbInterface) *StateDB {
+	return &StateDB{ inner, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+}

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -124,7 +124,7 @@ func (d iterativeDump) OnRoot(root common.Hash) {
 
 // DumpToCollector iterates the state according to the given options and inserts
 // the items into a collector for aggregation or serialization.
-func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte) {
+func (s *LegacyStateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte) {
 	// Sanitize the input to allow nil configs
 	if conf == nil {
 		conf = new(DumpConfig)
@@ -201,7 +201,7 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 }
 
 // RawDump returns the entire state an a single large object
-func (s *StateDB) RawDump(opts *DumpConfig) Dump {
+func (s *LegacyStateDB) RawDump(opts *DumpConfig) Dump {
 	dump := &Dump{
 		Accounts: make(map[common.Address]DumpAccount),
 	}
@@ -210,7 +210,7 @@ func (s *StateDB) RawDump(opts *DumpConfig) Dump {
 }
 
 // Dump returns a JSON string representing the entire state as a single json-object
-func (s *StateDB) Dump(opts *DumpConfig) []byte {
+func (s *LegacyStateDB) Dump(opts *DumpConfig) []byte {
 	dump := s.RawDump(opts)
 	json, err := json.MarshalIndent(dump, "", "    ")
 	if err != nil {
@@ -220,12 +220,12 @@ func (s *StateDB) Dump(opts *DumpConfig) []byte {
 }
 
 // IterativeDump dumps out accounts as json-objects, delimited by linebreaks on stdout
-func (s *StateDB) IterativeDump(opts *DumpConfig, output *json.Encoder) {
+func (s *LegacyStateDB) IterativeDump(opts *DumpConfig, output *json.Encoder) {
 	s.DumpToCollector(iterativeDump{output}, opts)
 }
 
 // IteratorDump dumps out a batch of accounts starts with the given start key
-func (s *StateDB) IteratorDump(opts *DumpConfig) IteratorDump {
+func (s *LegacyStateDB) IteratorDump(opts *DumpConfig) IteratorDump {
 	iterator := &IteratorDump{
 		Accounts: make(map[common.Address]DumpAccount),
 	}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -28,7 +28,7 @@ import (
 // NodeIterator is an iterator to traverse the entire state trie post-order,
 // including all of the contract code and contract state tries.
 type NodeIterator struct {
-	state *StateDB // State being iterated
+	state *LegacyStateDB // State being iterated
 
 	stateIt trie.NodeIterator // Primary iterator for the global state trie
 	dataIt  trie.NodeIterator // Secondary iterator for the data trie of a contract
@@ -44,7 +44,7 @@ type NodeIterator struct {
 }
 
 // NewNodeIterator creates an post-order state node iterator.
-func NewNodeIterator(state *StateDB) *NodeIterator {
+func NewNodeIterator(state *LegacyStateDB) *NodeIterator {
 	return &NodeIterator{
 		state: state,
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -67,7 +67,7 @@ type stateObject struct {
 	address  common.Address
 	addrHash common.Hash // hash of ethereum address of the account
 	data     Account
-	db       *StateDB
+	db       *LegacyStateDB
 
 	// DB error.
 	// State objects are used by the consensus core and VM which are
@@ -111,7 +111,7 @@ type Account struct {
 }
 
 // newObject creates a state object.
-func newObject(db *StateDB, address common.Address, data Account) *stateObject {
+func newObject(db *LegacyStateDB, address common.Address, data Account) *stateObject {
 	if data.Balance == nil {
 		data.Balance = new(big.Int)
 	}
@@ -466,7 +466,7 @@ func (s *stateObject) setBalance(amount *big.Int) {
 	s.data.Balance = amount
 }
 
-func (s *stateObject) deepCopy(db *StateDB) *stateObject {
+func (s *stateObject) deepCopy(db *LegacyStateDB) *stateObject {
 	stateObject := newObject(db, s.address, s.data)
 	if s.trie != nil {
 		stateObject.trie = db.db.CopyTrie(s.trie)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -448,9 +448,10 @@ func opBlockhash(pc *uint64, interpreter *GethEVMInterpreter, scope *ScopeContex
 	if substate.RecordReplay {
 		// convert vm.StateDB to state.StateDB and save block hash
 		defer func() {
-			statedb, ok := interpreter.evm.StateDB.(*state.StateDB)
-			if ok {
-				statedb.SubstateBlockHashes[num64] = common.BytesToHash(num.Bytes())
+			if statedb, ok := interpreter.evm.StateDB.(*state.StateDB); ok {
+				if legacy, ok := statedb.StateDbInterface.(*state.LegacyStateDB); ok {
+					legacy.SubstateBlockHashes[num64] = common.BytesToHash(num.Bytes())
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
This is a modification for Norma, which allows to replace the StateDB implementation used in Opera.

Note: GetOrNewStateObject is removed from the StateDB interface to avoid the need for exporting its return type.