### PR TITLE
Add BeginBlock into StateDB interface

### DIFF
--- a/core/state/adapter.go
+++ b/core/state/adapter.go
@@ -81,6 +81,7 @@ type StateDbInterface interface {
 
 	SetPrehashedCode(addr common.Address, hash common.Hash, code []byte)
 	GetSubstatePostAlloc() substate.SubstateAlloc
+	BeginBlock(number uint64)
 	EndBlock(number uint64)
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1129,6 +1129,10 @@ func (s *LegacyStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
 	return s.SubstatePostAlloc
 }
 
+func (s *LegacyStateDB) BeginBlock(number uint64) {
+	// not used by LegacyStateDB
+}
+
 func (s *LegacyStateDB) EndBlock(number uint64) {
 	// not used by LegacyStateDB
 }


### PR DESCRIPTION
Add BeginBlock into StateDB interface, for purpose of setting the blockNumber of logs in carmenStateDb.