### PR TITLE
Add Len/CountToPop into txs sorting structure

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -569,6 +569,25 @@ func (t *TransactionsByPriceAndNonce) Pop() {
 	heap.Pop(&t.heads)
 }
 
+// GetCountToPop provides the amount of txs, which will be removed if Pop is called
+func (t *TransactionsByPriceAndNonce) GetCountToPop() int {
+	acc, _ := Sender(t.signer, t.heads[0].tx)
+	if txs, ok := t.txs[acc]; ok {
+		return len(txs) + 1
+	}
+	return 0
+}
+
+// Len provides the total amount of txs in the structure
+func (t *TransactionsByPriceAndNonce) Len() int {
+	length := 0
+	for _, head := range t.heads {
+		acc, _ := Sender(t.signer, head.tx)
+		length += len(t.txs[acc]) + 1
+	}
+	return length
+}
+
 func (t *TransactionsByPriceAndNonce) Copy() *TransactionsByPriceAndNonce {
 	txsCopy := make(map[common.Address]Transactions, len(t.txs))
 	for k, v := range t.txs {


### PR DESCRIPTION
This is change to support more exact measuring of dropped transactions, requested in https://github.com/Fantom-foundation/go-opera-norma/pull/13 review.
We need a way to find out, how many txs is dropped, when the processing in interrupted (the total amount of txs in the structure) and when Pop() method is called. (drops all txs of the most priority sender)