### PR TITLE
Implement state abstraction and interpreter step function

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -54,6 +54,9 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 	}
 	return 0, nil
 }
+func MemoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
+	return memoryGasCost(mem, newMemSize)
+}
 
 // memoryCopierGas creates the gas functions for the following opcodes, and takes
 // the stack position of the operand which determines the size of the data to copy

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -36,7 +36,7 @@ type Stack struct {
 	data []uint256.Int
 }
 
-func newstack() *Stack {
+func NewStack() *Stack {
 	return stackPool.Get().(*Stack)
 }
 
@@ -53,6 +53,9 @@ func (st *Stack) Data() []uint256.Int {
 func (st *Stack) push(d *uint256.Int) {
 	// NOTE push limit (1024) is checked in baseCheck
 	st.data = append(st.data, *d)
+}
+func (st *Stack) Push(d *uint256.Int) {
+	st.push(d)
 }
 func (st *Stack) pushN(ds ...uint256.Int) {
 	// FIXME: Is there a way to pass args by pointers.


### PR DESCRIPTION
This PR adds an abstraction around the interpreter state and allows synchronous single stepping of the interpreter. This is necessary for integration with the conformance testing framework of Tosca.

There are some additional functions that need to be exposed so other modules can setup an interpreter state from scratch, like for stack and memory. I have decided to add public wrapper functions rather than making the existing functions public to avoid having to touch countless places where these functions are called.