### PR TITLE
metrics: use atomic type (#27121)

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -38,13 +38,13 @@ func NewCounter() Counter {
 	if !Enabled {
 		return NilCounter{}
 	}
-	return &StandardCounter{0}
+	return &StandardCounter{}
 }
 
 // NewCounterForced constructs a new StandardCounter and returns it no matter if
 // the global switch is enabled or not.
 func NewCounterForced() Counter {
-	return &StandardCounter{0}
+	return &StandardCounter{}
 }
 
 // NewRegisteredCounter constructs and registers a new StandardCounter.
@@ -115,27 +115,27 @@ func (NilCounter) Snapshot() Counter { return NilCounter{} }
 // StandardCounter is the standard implementation of a Counter and uses the
 // sync/atomic package to manage a single int64 value.
 type StandardCounter struct {
-	count int64
+	count atomic.Int64
 }
 
 // Clear sets the counter to zero.
 func (c *StandardCounter) Clear() {
-	atomic.StoreInt64(&c.count, 0)
+	c.count.Store(0)
 }
 
 // Count returns the current count.
 func (c *StandardCounter) Count() int64 {
-	return atomic.LoadInt64(&c.count)
+	return c.count.Load()
 }
 
 // Dec decrements the counter by the given amount.
 func (c *StandardCounter) Dec(i int64) {
-	atomic.AddInt64(&c.count, -i)
+	c.count.Add(-i)
 }
 
 // Inc increments the counter by the given amount.
 func (c *StandardCounter) Inc(i int64) {
-	atomic.AddInt64(&c.count, i)
+	c.count.Add(i)
 }
 
 // Snapshot returns a read-only copy of the counter.

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -25,7 +25,7 @@ func NewGauge() Gauge {
 	if !Enabled {
 		return NilGauge{}
 	}
-	return &StandardGauge{0}
+	return &StandardGauge{}
 }
 
 // NewRegisteredGauge constructs and registers a new StandardGauge.
@@ -101,7 +101,7 @@ func (NilGauge) Value() int64 { return 0 }
 // StandardGauge is the standard implementation of a Gauge and uses the
 // sync/atomic package to manage a single int64 value.
 type StandardGauge struct {
-	value int64
+	value atomic.Int64
 }
 
 // Snapshot returns a read-only copy of the gauge.
@@ -111,22 +111,22 @@ func (g *StandardGauge) Snapshot() Gauge {
 
 // Update updates the gauge's value.
 func (g *StandardGauge) Update(v int64) {
-	atomic.StoreInt64(&g.value, v)
+	g.value.Store(v)
 }
 
 // Value returns the gauge's current value.
 func (g *StandardGauge) Value() int64 {
-	return atomic.LoadInt64(&g.value)
+	return g.value.Load()
 }
 
 // Dec decrements the gauge's current value by the given amount.
 func (g *StandardGauge) Dec(i int64) {
-	atomic.AddInt64(&g.value, -i)
+	g.value.Add(-i)
 }
 
 // Inc increments the gauge's current value by the given amount.
 func (g *StandardGauge) Inc(i int64) {
-	atomic.AddInt64(&g.value, i)
+	g.value.Add(i)
 }
 
 // FunctionalGauge returns value from given function

--- a/metrics/meter.go
+++ b/metrics/meter.go
@@ -101,11 +101,7 @@ func NewRegisteredMeterForced(name string, r Registry) Meter {
 
 // MeterSnapshot is a read-only copy of another Meter.
 type MeterSnapshot struct {
-	// WARNING: The `temp` field is accessed atomically.
-	// On 32 bit platforms, only 64-bit aligned fields can be atomic. The struct is
-	// guaranteed to be so aligned, so take advantage of that. For more information,
-	// see https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
-	temp                           int64
+	temp                           atomic.Int64
 	count                          int64
 	rate1, rate5, rate15, rateMean float64
 }
@@ -173,7 +169,7 @@ type StandardMeter struct {
 	snapshot    *MeterSnapshot
 	a1, a5, a15 EWMA
 	startTime   time.Time
-	stopped     uint32
+	stopped     atomic.Bool
 }
 
 func newStandardMeter() *StandardMeter {
@@ -188,8 +184,8 @@ func newStandardMeter() *StandardMeter {
 
 // Stop stops the meter, Mark() will be a no-op if you use it after being stopped.
 func (m *StandardMeter) Stop() {
-	stopped := atomic.SwapUint32(&m.stopped, 1)
-	if stopped != 1 {
+	stopped := m.stopped.Swap(true)
+	if !stopped {
 		arbiter.Lock()
 		delete(arbiter.meters, m)
 		arbiter.Unlock()
@@ -207,7 +203,7 @@ func (m *StandardMeter) Count() int64 {
 
 // Mark records the occurrence of n events.
 func (m *StandardMeter) Mark(n int64) {
-	atomic.AddInt64(&m.snapshot.temp, n)
+	m.snapshot.temp.Add(n)
 }
 
 // Rate1 returns the one-minute moving average rate of events per second.
@@ -241,7 +237,14 @@ func (m *StandardMeter) RateMean() float64 {
 // Snapshot returns a read-only copy of the meter.
 func (m *StandardMeter) Snapshot() Meter {
 	m.lock.RLock()
-	snapshot := *m.snapshot
+	snapshot := MeterSnapshot{
+		count:    m.snapshot.count,
+		rate1:    m.snapshot.rate1,
+		rate5:    m.snapshot.rate5,
+		rate15:   m.snapshot.rate15,
+		rateMean: m.snapshot.rateMean,
+	}
+	snapshot.temp.Store(m.snapshot.temp.Load())
 	m.lock.RUnlock()
 	return &snapshot
 }
@@ -257,7 +260,7 @@ func (m *StandardMeter) updateSnapshot() {
 
 func (m *StandardMeter) updateMeter() {
 	// should only run with write lock held on m.lock
-	n := atomic.SwapInt64(&m.snapshot.temp, 0)
+	n := m.snapshot.temp.Swap(0)
 	m.snapshot.count += n
 	m.a1.Update(n)
 	m.a5.Update(n)


### PR DESCRIPTION
Backport of metrics improvement removing a race condition.

Upstream commit:
https://github.com/ethereum/go-ethereum/commit/ae93e0b484fa9345a3a9eb2a5f1ced9d450d2b52

Race condition being fixed:
```
==================
WARNING: DATA RACE
Read at 0x00c005cf8c30 by goroutine 3549:
  github.com/ethereum/go-ethereum/metrics.(*StandardMeter).Snapshot()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/metrics/meter.go:244 +0x73
  github.com/ethereum/go-ethereum/metrics/exp.Exp.Handler.func1()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/go-ethereum-substate@v1.1.1-0.20231003122306-febfe681b4a7/metrics/prometheus/prometheus.go:55 +0x321
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2136 +0x47
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2514 +0xbc
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2938 +0x2a1
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:2009 +0xc24
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3086 +0x4f

Previous write at 0x00c005cf8c30 by goroutine 2517:
  sync/atomic.AddInt64()
      /usr/local/go/src/runtime/race_amd64.s:289 +0xb
  sync/atomic.AddInt64()
      <autogenerated>:1 +0x15
  github.com/Fantom-foundation/go-opera/gossip.(*Service).processEvent()
      /home/jand/go-opera-norma/gossip/c_event_callbacks.go:261 +0x5dd
  github.com/Fantom-foundation/go-opera/gossip.newService.func2()
      /home/jand/go-opera-norma/gossip/service.go:259 +0xa4
  github.com/Fantom-foundation/go-opera/gossip.(*handler).makeDagProcessor.func3()
      /home/jand/go-opera-norma/gossip/handler.go:480 +0x16e
  github.com/Fantom-foundation/lachesis-base/gossip/dagordering.(*EventsBuffer).processCompleteEvent()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagordering/event_buffer.go:145 +0x128
  github.com/Fantom-foundation/lachesis-base/gossip/dagordering.(*EventsBuffer).pushEvent()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagordering/event_buffer.go:88 +0x152
  github.com/Fantom-foundation/lachesis-base/gossip/dagordering.(*EventsBuffer).PushEvent()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagordering/event_buffer.go:66 +0x324
  github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor.(*Processor).process()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagprocessor/processor.go:181 +0x115
  github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor.(*Processor).Enqueue.func2()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagprocessor/processor.go:146 +0x5b4
  github.com/Fantom-foundation/lachesis-base/utils/workers.worker()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/utils/workers/workers.go:66 +0xf2
  github.com/Fantom-foundation/lachesis-base/utils/workers.(*Workers).Start.func1()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/utils/workers/workers.go:31 +0x90

Goroutine 3549 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3086 +0x80c
  net/http.(*Server).ListenAndServe()
      /usr/local/go/src/net/http/server.go:2985 +0xbc
  net/http.ListenAndServe()
      /usr/local/go/src/net/http/server.go:3239 +0x114
  github.com/Fantom-foundation/go-opera/debug.StartPProf.func1()
      /home/jand/go-opera-norma/debug/flags.go:262 +0x115

Goroutine 2517 (running) created at:
  github.com/Fantom-foundation/lachesis-base/utils/workers.(*Workers).Start()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/utils/workers/workers.go:29 +0x32
  github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor.(*Processor).Start()
      /home/jand/go/pkg/mod/github.com/!fantom-foundation/lachesis-base@v0.0.0-20230629034932-42bae8eeb426/gossip/dagprocessor/processor.go:80 +0x44
  github.com/Fantom-foundation/go-opera/gossip.(*handler).Start()
      /home/jand/go-opera-norma/gossip/handler.go:694 +0x9bc
  github.com/Fantom-foundation/go-opera/gossip.(*Service).Start()
      /home/jand/go-opera-norma/gossip/service.go:451 +0x504
==================
```