### PR TITLE
Mark RETURN instruction as a return-value modifying instruction

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -1020,6 +1020,7 @@ func newFrontierInstructionSet() JumpTable {
 			maxStack:   maxStack(2, 0),
 			memorySize: memoryReturn,
 			halts:      true,
+			returns:    true,
 		},
 		SELFDESTRUCT: {
 			execute:    opSuicide,


### PR DESCRIPTION
Unlike [REVERT](https://github.com/Fantom-foundation/go-ethereum-substate/blob/7bcaef582b5d1fd7f03926a4e6042c43e5aceeb8/core/vm/jump_table.go#L170), [RETURN](https://github.com/Fantom-foundation/go-ethereum-substate/blob/7bcaef582b5d1fd7f03926a4e6042c43e5aceeb8/core/vm/jump_table.go#L1016) is not marked as a return-data modifying instruction. With this PR this is corrected.