### PR TITLE
Rename p2p db dir in datadir to "p2p"

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -309,7 +309,7 @@ func (n *Node) openDataDir() error {
 		return nil // ephemeral
 	}
 
-	instdir := filepath.Join(n.config.DataDir, n.config.name())
+	instdir := n.config.instanceDir()
 	if err := os.MkdirAll(instdir, 0700); err != nil {
 		return err
 	}


### PR DESCRIPTION
Sonic currently creates a directory "Sonic" inside of the datadir directory ("go-opera" in go-opera) and stores p2p data (discovered nodes and the node p2p key) there.

This PR renames this directory to "p2p".
(Change requested by @JirkaMe)

It also removes some backward compatibility code related to geth 1.4.