### PR TITLE
Warn when dialing static peer fails

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -496,7 +496,10 @@ func (t *dialTask) run(d *dialScheduler) {
 		// For static nodes, resolve one more time if dialing fails.
 		if _, ok := err.(*dialError); ok && t.flags&staticDialedConn != 0 {
 			if t.resolve(d) {
-				t.dial(d, t.dest)
+				err = t.dial(d, t.dest)
+			}
+			if err != nil {
+				d.log.Warn("Failed to dial static peer", "id", t.dest.ID(), "addr", nodeAddr(t.dest), "conn", t.flags, "err", cleanupDialErr(err))
 			}
 		}
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -971,6 +971,9 @@ func (srv *Server) SetupConn(fd net.Conn, flags connFlag, dialDest *enode.Node) 
 
 	err := srv.setupConn(c, flags, dialDest)
 	if err != nil {
+		if c.is(staticDialedConn) {
+			srv.log.Warn("Failed static peer setup", "addr", c.fd.RemoteAddr(), "conn", c.flags, "err", err)
+		}
 		c.close(err)
 	}
 	return err


### PR DESCRIPTION
Failing to connect to a static peer is currently hidden in TRACE-level log message.
This adds WARN-level log message, when dialing a configured static peer fails.
This does not affect non-static peers.

For static peers, the client tries to resolve the IP of the peer by the public key if the IP is not defined, but also when the first dial fails. Then, if the resolving succeeded, the client dials the peer second time.
This warning is reported when the last dial attempt fails, with the error from the last attempt.

```
WARN [05-22|18:21:38.940] Failed to dial static peer               id=b8ed5674f113f086 addr=1.2.3.4:5050               conn=staticdial err="dial tcp 1.2.3.4:5050: connect: connection refused"
```