### PR TITLE
Close all opened RPC connections

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -125,7 +125,7 @@ func (s *Server) Stop() {
 	log.Debug("RPC server shutting down")
 	s.codecs.Each(func(c interface{}) bool {
 		c.(ServerCodec).close()
-		return true
+		return false
 	})
 	s.services.callWG.Wait()
 }


### PR DESCRIPTION
Because of wrong argument for Each function for closing all rpc connections, only one codec was closed during server stop procedure and remaining were not closed.

In this case is used Set from `github.com/deckarep/golang-set` which defines Each function like this:
```
func (set *threadSafeSet) Each(cb func(interface{}) bool) {
	set.RLock()
	for elem := range set.s {
		if cb(elem) {
			break
		}
	}
	set.RUnlock()
}
```
So if we return true in calling this function:
```
	s.codecs.Each(func(c interface{}) bool {
		c.(ServerCodec).close()
		return true
	})
```
it will only process one codec from the set and then exits this Each function. That's why it is changed to false in this PR to process all codecs.